### PR TITLE
Updated kubertenes version as 1.11.4 is not supported.

### DIFF
--- a/labs/vstsextend/kubernetes/armtemplate/azuredeploy.json
+++ b/labs/vstsextend/kubernetes/armtemplate/azuredeploy.json
@@ -146,8 +146,9 @@
         },
         "kubernetesVersion": {
             "type": "string",
-            "defaultValue": "1.11.4",
+            "defaultValue": "1.11.5",
             "allowedValues": [
+                "1.11.5",
                 "1.11.4",
                 "1.11.3",
                 "1.10.9",


### PR DESCRIPTION
This issue explaain the error I had:
https://github.com/MicrosoftDocs/azure-docs/issues/19881

had this error on deploying the template in the handson lab:
Exception Details:
Error Code: InvalidParameter
Message: Provisioning of resource(s) for container service <AKSresourceName> in resource group <resourceGroupName> failed. Message: {
"code": "InvalidParameter",
"message": "The value of parameter orchestratorProfile.OrchestratorVersion is invalid.",
"target": "orchestratorProfile.OrchestratorVersion"
}. Details: