### PR TITLE
Added npm install to fix jest dependency

### DIFF
--- a/labs/vstsextend/github-azurepipelines/readme.md
+++ b/labs/vstsextend/github-azurepipelines/readme.md
@@ -249,7 +249,9 @@ Now that we have our CI successfully built, it's time to deploy but how do we kn
        inputs:
          command: 'custom'
          customcommand: 'install --production'
-     - script: 'npm test'
+     - script: |
+         npm install
+         npm test
        displayName: 'Run unit tests'
        continueOnError: true
      - task: PublishTestResults@2


### PR DESCRIPTION
The best way to fix #454 would be to change the `package.json` file of the [ContosoAir ](https://github.com/microsoft/ContosoAir) project. But since this project is archived and set to read-only mode no changes can be made there.
Therefore adding an `npm install` is fixing the dependency issue by installing `jest `so that the unit tests can be executed and the pipeline doesn't fail.