### PR TITLE
Update readme.md

### DIFF
--- a/labs/azuredevops/packagemanagement/readme.md
+++ b/labs/azuredevops/packagemanagement/readme.md
@@ -125,7 +125,7 @@ redirect_from: "/labs/vsts/packagemanagement/index.htm"
 1. Execute the line below to create a **.nupkg** file from the project. Note that this is a quick shortcut to package the NuGet bits together for deployment. NuGet is very customizable and offers a lot of great flexibility for providing detailed information for consumers. You can learn more over on the [NuGet package creation page](https://docs.microsoft.com/en-us/nuget/create-packages/overview-and-workflowhttps:/docs.microsoft.com/en-us/nuget/create-packages/overview-and-workflow).
 
     ```
-    ./nuget.exe pack PartsUnlimited.Shared.csproj
+    ./nuget.exe pack ./PartsUnlimited.Shared.csproj
     ```
 1. NuGet builds a minimal package based on the information it is able to pull from the project. For example, note that the name is **PartsUnlimited.Shared.1.0.0.nupkg**. That version number was pulled from the assembly.
 


### PR DESCRIPTION
”Couldn't find file" error occurs when executing "./nuget.exe pack PartsUnlimited.Shared.csproj".
"./nuget.exe pack ./PartsUnlimited.Shared.csproj" is OK.