### PR TITLE
Package Management lab: Restarting  second VS studio instance, so that it has the new source.

### DIFF
--- a/labs/azuredevops/packagemanagement/readme.md
+++ b/labs/azuredevops/packagemanagement/readme.md
@@ -67,6 +67,8 @@ redirect_from: "/labs/vsts/packagemanagement/index.htm"
 
     ![](images/006.png)
 
+1. Close and Reopen the other Visual Studio instance used for cloning the PartsUnlimited repository ( <a href="../prereq/"> prerequisites </a> Task 2), so that it shows this new source.
+
 <a name="Ex1Task2"></a>
 ### Task 2: Creating and publishing a NuGet package ###
 


### PR DESCRIPTION
Many attendees get the issue that if PartsUnlimited VS was opened when setting the package source on second VS instance, they are not able to find the shared package later.