### PR TITLE
Add billing subscription prerequisite and other fixes

### DIFF
--- a/labs/azuredevops/advancedsecurity/readme.md
+++ b/labs/azuredevops/advancedsecurity/readme.md
@@ -369,7 +369,7 @@ Code scanning in GitHub Advanced Security for Azure DevOps lets you analyze the 
 4.	Click on Detections to see the different builds that detected this alert.
 
 
-    > ProTip!
+    > **ProTip!**
     > When a vulnerable component is no longer detected in the latest build for pipelines with the dependency scanning task, the state of the associated alert is automatically changed to Closed. To see these resolved alerts, you can use the State filter in the main toolbar and select Closed.
 
 

--- a/labs/azuredevops/advancedsecurity/readme.md
+++ b/labs/azuredevops/advancedsecurity/readme.md
@@ -187,9 +187,6 @@ When a Dependency Alert is created in Azure DevOps Advanced Security, it will co
     The build will run automatically, initiating the dependency scanning task and publishing the results to Advanced Security and alert automatically closed.
 
 
-    >**ProTip!** Squash Merge is important. If we just commit, the exposed credential will still be in the history. To avoid this, fix code, use a Squash Merge, push it to repo, and you're done!
-
-
 1.	Once the pipeline has been completed, **eShopOnWeb**, go to the Azure DevOps Advanced Security dashboard and click on Dependencies.
 
 1.	You will see that the alert *Improper Input Validation in IpMatcher....*... no longer exists, as it is now closed.

--- a/labs/azuredevops/advancedsecurity/readme.md
+++ b/labs/azuredevops/advancedsecurity/readme.md
@@ -41,6 +41,7 @@ In this lab, you will see how you can use Advanced Security to protect the Azure
 ### Before you begin
 
 - This lab requires you to complete task 1 from the <a href="../prereq-advsec/">prerequisite</a> instructions.
+- Since GitHub Advanced Security for Azure DevOps requires billing, you must have <a href="https://learn.microsoft.com/en-us/azure/devops/organizations/billing/set-up-billing-for-your-organization-vs?view=azure-devops">set up a billing subscription</a> for your organization.
 
 
 ### Task 1: Enable Advanced Security from Portal

--- a/labs/azuredevops/advancedsecurity/readme.md
+++ b/labs/azuredevops/advancedsecurity/readme.md
@@ -369,10 +369,6 @@ Code scanning in GitHub Advanced Security for Azure DevOps lets you analyze the 
 4.	Click on Detections to see the different builds that detected this alert.
 
 
-    > **ProTip!**
-    > When a vulnerable component is no longer detected in the latest build for pipelines with the dependency scanning task, the state of the associated alert is automatically changed to Closed. To see these resolved alerts, you can use the State filter in the main toolbar and select Closed.
-
-
 #### Fixing the Code to resolve the alert
 1.	This is simple to fix using the method using parameters with dynamic SQL described in the Remediation steps.
 


### PR DESCRIPTION
The newest lab for GitHub Advanced Security for Azure DevOps does not mention billing. However, without a configured billing subscription the lab does not work. In addition, there are a couple other issues I have fixed:

- Added necessary billing setup to prerequisites with link to official documentation.
- Removed the tip about squash merging from the dependency scanning lab (doesn't make sense here).